### PR TITLE
Ensure tokens generated by Lexer are continous

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,6 +8,7 @@
 
 1.11.0
 
+ * Fixed parsing of wiki files to ensure continous tokens, required for IntelliJ 2020.2. See https://github.com/gshakhn/idea-fitnesse/issues/55.
  * Added plugin logo (https://github.com/gshakhn/idea-fitnesse/issues/51).
 
 1.10.1

--- a/src/test/scala/fitnesse/idea/lexer/MiscLexerSuite.scala
+++ b/src/test/scala/fitnesse/idea/lexer/MiscLexerSuite.scala
@@ -107,8 +107,9 @@ class MiscLexerSuite extends LexerSuite {
   test("Collapsible section") {
     assertResult(
       List(
-        (FitnesseTokenType.COLLAPSIBLE_START, "!* abc\ndef\n*!"),
+        (FitnesseTokenType.COLLAPSIBLE_START, "!* "),
         (FitnesseTokenType.WORD, "abc"),
+        (FitnesseTokenType.LINE_TERMINATOR, "\n"),
         (FitnesseTokenType.WORD, "def"),
         (FitnesseTokenType.LINE_TERMINATOR, "\n"),
         (FitnesseTokenType.COLLAPSIBLE_END, "*!"),
@@ -119,19 +120,71 @@ class MiscLexerSuite extends LexerSuite {
     }
   }
 
+  test("Collapsed section") {
+    assertResult(
+      List(
+        (FitnesseTokenType.COLLAPSIBLE_START, 0, 7, "!****< "),
+        (FitnesseTokenType.WORD, 7, 10, "bbc"),
+        (FitnesseTokenType.LINE_TERMINATOR, 10, 11, "\n"),
+        (FitnesseTokenType.WORD, 11, 14, "def"),
+        (FitnesseTokenType.LINE_TERMINATOR, 14, 15, "\n"),
+        (FitnesseTokenType.COLLAPSIBLE_END, 15, 17, "*!"),
+        (FitnesseTokenType.WHITE_SPACE, 17, 18, " "),
+        (FitnesseTokenType.WORD, 18, 22, "word")
+      )) {
+      lexWithOffset("!****< bbc\ndef\n*! word")
+    }
+  }
+
+  test("Collapsible section multi word title") {
+    assertResult(
+      List(
+        (FitnesseTokenType.COLLAPSIBLE_START, 0, 4, "!*> "),
+        (FitnesseTokenType.WORD, 4, 9, "Extra"),
+        (FitnesseTokenType.WHITE_SPACE, 9, 10, " "),
+        (FitnesseTokenType.WORD, 10, 16, "Import"),
+        (FitnesseTokenType.LINE_TERMINATOR, 16, 17, "\n"),
+        (FitnesseTokenType.LINE_TERMINATOR, 17, 18, "\n"),
+        (FitnesseTokenType.WORD, 18, 20, "Hi"),
+        (FitnesseTokenType.LINE_TERMINATOR, 20, 21, "\n"),
+        (FitnesseTokenType.COLLAPSIBLE_END, 21, 24, "*!\n"),
+        (FitnesseTokenType.LINE_TERMINATOR, 24, 25, "\n")
+      )) {
+      lexWithOffset("!*> Extra Import\n\nHi\n*!\n\n")
+    }
+  }
+
   test("Collapsible section containing a table") {
     assertResult(
       List(
-        (FitnesseTokenType.COLLAPSIBLE_START, "!* title\n|abc|\n|xyz|\n*!"),
-        (FitnesseTokenType.WORD, "title"),
-        (FitnesseTokenType.TABLE_START, "|"),
-        (FitnesseTokenType.WORD, "abc"),
-        (FitnesseTokenType.ROW_END, "|\n|"),
-        (FitnesseTokenType.WORD, "xyz"),
-        (FitnesseTokenType.TABLE_END, "|\n"),
-        (FitnesseTokenType.COLLAPSIBLE_END, "|\n*!")
+        (FitnesseTokenType.COLLAPSIBLE_START, 0, 3, "!* "),
+        (FitnesseTokenType.WORD, 3, 8, "title"),
+        (FitnesseTokenType.LINE_TERMINATOR, 8, 9, "\n"),
+        (FitnesseTokenType.TABLE_START, 9, 10, "|"),
+        (FitnesseTokenType.WORD, 10, 13, "abc"),
+        (FitnesseTokenType.ROW_END, 13, 16, "|\n|"),
+        (FitnesseTokenType.WORD, 16, 19, "xyz"),
+        (FitnesseTokenType.TABLE_END, 19, 21, "|\n"),
+        (FitnesseTokenType.COLLAPSIBLE_END, 21, 23, "*!")
       )) {
-      lex("!* title\n|abc|\n|xyz|\n*!")
+      lexWithOffset("!* title\n|abc|\n|xyz|\n*!")
+    }
+  }
+
+  test("Collapsible section containing a table followed by newline") {
+    assertResult(
+      List(
+        (FitnesseTokenType.COLLAPSIBLE_START, 0, 3, "!* "),
+        (FitnesseTokenType.WORD, 3, 8, "title"),
+        (FitnesseTokenType.LINE_TERMINATOR, 8, 9, "\n"),
+        (FitnesseTokenType.TABLE_START, 9, 10, "|"),
+        (FitnesseTokenType.WORD, 10, 13, "abc"),
+        (FitnesseTokenType.ROW_END, 13, 16, "|\n|"),
+        (FitnesseTokenType.WORD, 16, 19, "xyz"),
+        (FitnesseTokenType.TABLE_END, 19, 21, "|\n"),
+        (FitnesseTokenType.COLLAPSIBLE_END, 21, 24, "*!\n")
+      )) {
+      lexWithOffset("!* title\n|abc|\n|xyz|\n*!\n")
     }
   }
 

--- a/src/test/scala/fitnesse/idea/lexer/TableLexerSuite.scala
+++ b/src/test/scala/fitnesse/idea/lexer/TableLexerSuite.scala
@@ -315,4 +315,51 @@ class TableLexerSuite extends LexerSuite {
       lexWithOffset("!||\n||")
     }
   }
+
+  test("Formatted cells should not make table offsets overlap") {
+    assertResult(
+      List(
+        (FitnesseTokenType.TABLE_START, 0, 1, "|"),
+        (FitnesseTokenType.BOLD,        1, 8, "'''E'''"),
+        (FitnesseTokenType.CELL_END,    8, 9, "|"),
+        (FitnesseTokenType.ITALIC,      9, 14, "''A''"),
+        (FitnesseTokenType.TABLE_END,   14, 15, "|")
+      )) {
+      lexWithOffset("|'''E'''|''A''|")
+    }
+  }
+
+  test("Formatted cells should not make table offsets overlap with multiple rows") {
+    assertResult(
+      List(
+        (FitnesseTokenType.TABLE_START, 0, 1, "|"),
+        (FitnesseTokenType.BOLD,        1, 8, "'''E'''"),
+        (FitnesseTokenType.CELL_END,    8, 9, "|"),
+        (FitnesseTokenType.ITALIC,      9, 14, "''A''"),
+        (FitnesseTokenType.ROW_END,     14, 17, "|\n|"),
+        (FitnesseTokenType.BOLD,        17, 24, "'''E'''"),
+        (FitnesseTokenType.CELL_END,    24, 25, "|"),
+        (FitnesseTokenType.ITALIC,      25, 30, "''A''"),
+        (FitnesseTokenType.TABLE_END,   30, 31, "|")
+      )) {
+      lexWithOffset("|'''E'''|''A''|\n|'''E'''|''A''|")
+    }
+  }
+
+  test("Formatted cells should not make table offsets overlap with multiple rows and text after") {
+    assertResult(
+      List(
+        (FitnesseTokenType.TABLE_START, 0, 1, "|"),
+        (FitnesseTokenType.BOLD,        1, 8, "'''E'''"),
+        (FitnesseTokenType.CELL_END,    8, 9, "|"),
+        (FitnesseTokenType.ITALIC,      9, 14, "''A''"),
+        (FitnesseTokenType.ROW_END,     14, 17, "|\n|"),
+        (FitnesseTokenType.BOLD,        17, 24, "'''E'''"),
+        (FitnesseTokenType.CELL_END,    24, 25, "|"),
+        (FitnesseTokenType.ITALIC,      25, 30, "''A''"),
+        (FitnesseTokenType.TABLE_END,   30, 32, "|\n")
+      )) {
+      lexWithOffset("|'''E'''|''A''|\n|'''E'''|''A''|\n")
+    }
+  }
 }

--- a/src/test/scala/fitnesse/idea/parser/MiscParserSuite.scala
+++ b/src/test/scala/fitnesse/idea/parser/MiscParserSuite.scala
@@ -49,16 +49,18 @@ class MiscParserSuite extends ParserSuite {
       Node(FitnesseElementType.FILE, List(
         Node(FitnesseElementType.COLLAPSIBLE, List(
           Leaf(FitnesseTokenType.COLLAPSIBLE_START, "!* "),
-          Leaf(FitnesseTokenType.WORD, "title\n"),
+          Leaf(FitnesseTokenType.WORD, "title"),
+          Leaf(FitnesseTokenType.WHITE_SPACE, "\n"),
           Node(TableElementType.DECISION_TABLE, List(
             Leaf(FitnesseTokenType.TABLE_START,"|"),
             Node(FitnesseElementType.ROW, List(
               Node(FitnesseElementType.FIXTURE_CLASS, List(
                 Leaf(FitnesseTokenType.WORD, "abc")
               ))
-            ))
+            )),
+            Leaf(FitnesseTokenType.TABLE_END,"|\n")
           )),
-          Leaf(FitnesseTokenType.COLLAPSIBLE_END, "|\n*!\n")
+          Leaf(FitnesseTokenType.COLLAPSIBLE_END, "*!\n")
         ))
       ))
     ) {


### PR DESCRIPTION
Ensure start/end offsets of the tokens generated when parsing wiki pages do not have gaps between them.

fixes #55