### PR TITLE
Fix ConfigurationFactory.getId issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,11 +46,17 @@ def IDEA_VERSIONS = [
         URL: 'https://download.jetbrains.com/idea/ideaIC-2016.1.4.tar.gz',
         CSUM: 'b64767d87dbaae7e1511666fc032cf356e326770090e3a141969909d09670345',
         JAVA: '1.8'
+    ],
+    17: [
+        ID: 'IC-173.4710.11',
+        URL: 'https://download.jetbrains.com/idea/ideaIC-2017.3.7.tar.gz',
+        CSUM: '1b2f7084ffabb6bde29edf3a33ed3cae56fcb72bca2ca5ebab925730528cb3b4',
+        JAVA: '1.8'
     ]
 ]
 
 def idea_version = System.getenv('IDEA_VERSION')
-def IDEA = IDEA_VERSIONS[idea_version ? idea_version.toInteger() : 15]
+def IDEA = IDEA_VERSIONS[idea_version ? idea_version.toInteger() : 17]
 
 def IDEA_SDK_NAME = "IntelliJ IDEA Community Edition ${IDEA.ID}"
 def IDEA_LIB = "lib/sdk/idea-${IDEA.ID}/lib"

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ description = """<p>Language support for <a href="http://fitnesse.org>">FitNesse
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url "http://dl.bintray.com/fitnesse/edge"
         }
@@ -78,11 +78,11 @@ dependencies {
                                'jdom.jar', 'picocontainer.jar', 'trove4j.jar',])
 
     testCompile configurations.ideaSdk
-    testCompile 'org.scalatest:scalatest_2.11:2.2.5'
+    testCompile 'org.scalatest:scalatest_2.11:2.2.6'
     testCompile 'org.mockito:mockito-core:1.10.19'
 
     // Scalatest requires:
-    testRuntime 'org.pegdown:pegdown:1.1.0'
+    testRuntime 'org.pegdown:pegdown:1.6.0'
     testRuntime files("$jdkHome/lib/tools.jar")
 }
 

--- a/src/main/scala/fitnesse/idea/run/FitNesseTestRunConfigurationProducer.scala
+++ b/src/main/scala/fitnesse/idea/run/FitNesseTestRunConfigurationProducer.scala
@@ -98,6 +98,8 @@ class FitnesseRunConfigurationType extends ConfigurationType {
 
     override def getIcon: Icon = FitnesseFileType.FILE_ICON
 
+    override def getId: String = getName
+
     override def createTemplateConfiguration(project: Project) = new FitnesseRunConfiguration(getDisplayName(), project, this)
   }
 

--- a/src/test/scala/fitnesse/idea/fixtureclass/FitNesseLineMarkerProviderTest.scala
+++ b/src/test/scala/fitnesse/idea/fixtureclass/FitNesseLineMarkerProviderTest.scala
@@ -3,6 +3,7 @@ package fitnesse.idea.fixtureclass
 import java.util
 
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
+import com.intellij.mock.MockPsiFile
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.impl.light.JavaIdentifier
@@ -23,6 +24,7 @@ class FitNesseLineMarkerProviderTest extends PsiSuite {
     when(method.getParent).thenReturn(clazz)
     when(method.getText).thenReturn("methodName")
     when(method.getTextRange).thenReturn(new TextRange(1, 3))
+    when(method.getContainingFile).thenReturn(new MockPsiFile(myPsiManager))
     val myFixtureClass = mock[FixtureClass]
     when(myStubIndex.get(m_eq(FixtureClassIndex.KEY), m_eq("methodName"), any[Project], any[GlobalSearchScope])).thenReturn(List(myFixtureClass).asJava)
 

--- a/src/test/scala/fitnesse/idea/parser/ParserSuite.scala
+++ b/src/test/scala/fitnesse/idea/parser/ParserSuite.scala
@@ -1,5 +1,6 @@
 package fitnesse.idea.parser
 
+import com.intellij.core.CoreApplicationEnvironment
 import com.intellij.lang._
 import com.intellij.lang.impl.PsiBuilderFactoryImpl
 import com.intellij.lang.injection.MultiHostInjector
@@ -13,11 +14,14 @@ import com.intellij.openapi.fileEditor.impl.FileDocumentManagerImpl
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.impl.ProgressManagerImpl
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.roots.impl.{DirectoryIndexImpl, ProjectFileIndexImpl}
+import com.intellij.psi.impl.smartPointers.SmartPointerManagerImpl
 import com.intellij.psi.impl.source.SourceTreeToPsiMap
 import com.intellij.psi.impl.source.tree.{FileElement, CompositeElement}
 import com.intellij.psi.impl.{PsiFileFactoryImpl, PsiManagerEx}
 import com.intellij.psi.tree.IElementType
-import com.intellij.psi.{PsiFileFactory, SingleRootFileViewProvider}
+import com.intellij.psi.{PsiFileFactory, PsiManager, SingleRootFileViewProvider, SmartPointerManager}
 import com.intellij.testFramework.LightVirtualFile
 import com.intellij.util.Function
 import fitnesse.idea.filetype.FitnesseLanguage
@@ -26,7 +30,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 
 trait ParserSuite extends FunSuite with Matchers with BeforeAndAfterAll {
   val parserDefinition = new FitnesseParserDefinition
-  val myTestRootDisposable = new Disposable {
+  val myTestRootDisposable: Disposable = new Disposable {
     def dispose(): Unit = {}
   }
 
@@ -52,14 +56,23 @@ trait ParserSuite extends FunSuite with Matchers with BeforeAndAfterAll {
     Extensions.registerAreaClass("IDEA_PROJECT", null)
     Extensions.registerAreaClass(MultiHostInjector.MULTIHOST_INJECTOR_EP_NAME.getName, null)
 
+    CoreApplicationEnvironment.registerApplicationExtensionPoint(MetaLanguage.EP_NAME, classOf[MetaLanguage])
+
     app = new MockApplicationEx(myTestRootDisposable)
     myProject = new MockProjectEx(myTestRootDisposable)
     myPsiManager = new MockPsiManager(myProject)
     myPsiFileFactory = new PsiFileFactoryImpl(myPsiManager)
 
     myProject.getPicoContainer.registerComponentInstance(classOf[PsiFileFactory].getName, myPsiFileFactory)
+    myProject.getPicoContainer.registerComponentInstance(classOf[PsiManager].getName, myPsiManager)
 
     ApplicationManager.setApplication(app, myTestRootDisposable)
+
+    val projectFileIndex = new ProjectFileIndexImpl(
+      myProject,
+      new DirectoryIndexImpl(myProject),
+      new com.intellij.openapi.fileTypes.MockFileTypeManager
+    )
 
     app.getPicoContainer.registerComponentInstance(classOf[FileTypeManager].getName, new MockFileTypeManager(new MockLanguageFileType(parserDefinition.getFileNodeType.getLanguage, "txt")))
     app.getPicoContainer.registerComponentInstance(classOf[EditorFactory].getName, editorFactory)
@@ -67,6 +80,8 @@ trait ParserSuite extends FunSuite with Matchers with BeforeAndAfterAll {
     app.getPicoContainer.registerComponentInstance(classOf[DefaultASTFactory].getName, new DefaultASTFactoryImpl)
     app.getPicoContainer.registerComponentInstance(classOf[PsiBuilderFactory].getName, new PsiBuilderFactoryImpl)
     app.getPicoContainer.registerComponentInstance(classOf[ProgressManager].getName,  new ProgressManagerImpl)
+    app.getPicoContainer.registerComponentInstance(classOf[ProjectFileIndex].getName,  projectFileIndex)
+    app.getPicoContainer.registerComponentInstance(classOf[SmartPointerManager].getName,  new SmartPointerManagerImpl(myProject))
 
     LanguageParserDefinitions.INSTANCE.addExplicitExtension(parserDefinition.getFileNodeType.getLanguage, parserDefinition)
   }
@@ -79,8 +94,11 @@ trait ParserSuite extends FunSuite with Matchers with BeforeAndAfterAll {
     app.getPicoContainer.unregisterComponent(classOf[DefaultASTFactory].getName)
     app.getPicoContainer.unregisterComponent(classOf[PsiBuilderFactory].getName)
     app.getPicoContainer.unregisterComponent(classOf[ProgressManager].getName)
+    app.getPicoContainer.unregisterComponent(classOf[ProjectFileIndex].getName)
+    app.getPicoContainer.unregisterComponent(classOf[SmartPointerManager].getName)
 
     myProject.getPicoContainer.unregisterComponent(classOf[PsiFileFactory].getName)
+    myProject.getPicoContainer.unregisterComponent(classOf[PsiManager].getName)
   }
 
   abstract class Tree

--- a/src/test/scala/fitnesse/idea/psi/PsiSuite.scala
+++ b/src/test/scala/fitnesse/idea/psi/PsiSuite.scala
@@ -64,7 +64,7 @@ trait PsiSuite extends ParserSuite with MockitoSugar {
     assert(fileNode.isParsed)
     val indexFile: File = File.createTempFile("idea", "fitnesse")
     val persistentStringEnumerator = new PersistentStringEnumerator(indexFile)
-    val stubSerializationHelper = new StubSerializationHelper(persistentStringEnumerator)
+    val stubSerializationHelper = new StubSerializationHelper(persistentStringEnumerator, myTestRootDisposable)
 
     stubSerializationHelper.assignId(PsiFileStubImpl.TYPE)
     stubSerializationHelper.assignId(FitnesseElementType.DECISION_INPUT)


### PR DESCRIPTION
Since IntelliJ 2021.3 plugins are required to override `ConfigurationFactory.getId`. This method did not even exists before 2017.3, meaning it was required to update the IntelliJ version.

Also updates some test dependencies because I got NullPointerExceptions when running tests that disappeared after updating.

PS!
I don't have any prior experience writing Scala or IntelliJ plugins, if something seems wrong then please let me know.
