### PR TITLE
Fix "Use FitNesse jar bundled with the plugin" checkbox value not being saved

### DIFF
--- a/src/main/scala/fitnesse/idea/run/FitnesseRunConfiguration.scala
+++ b/src/main/scala/fitnesse/idea/run/FitnesseRunConfiguration.scala
@@ -170,6 +170,7 @@ class FitnesseRunConfiguration(testFrameworkName: String, project: Project, fact
     super.readExternal(element)
     wikiPageName = JDOMExternalizer.readString(element, "wikiPageName")
     fitnesseRoot = JDOMExternalizer.readString(element, "fitnesseRoot")
+    useFitNesseJar = JDOMExternalizer.readBoolean(element, "useFitNesseJar")
   }
 
   @throws[WriteExternalException]
@@ -177,5 +178,6 @@ class FitnesseRunConfiguration(testFrameworkName: String, project: Project, fact
     super.writeExternal(element)
     JDOMExternalizer.write(element, "wikiPageName", wikiPageName)
     JDOMExternalizer.write(element, "fitnesseRoot", fitnesseRoot)
+    JDOMExternalizer.write(element, "useFitNesseJar", useFitNesseJar)
   }
 }


### PR DESCRIPTION
The value of the "Use FitNesse jar bundled with the plugin" checkbox in the Run Configuration window was not saved to disk and it was reset to the default value after restart.

This fixes the issue by writing/reading the "useFitNesseJar" value to/from the xml configuration.